### PR TITLE
Added ROS Bridge Creation

### DIFF
--- a/Bridge.sh
+++ b/Bridge.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+export ROS_MASTER_URI=http://localhost:11311  
+echo ''
+echo 'ROS MASTER SET'
+echo ''
+source /opt/ros/foxy/setup.bash
+echo ''
+echo '----FOXY----'
+source /home/siddhant/ros_bridge_ws/install/setup.bash
+echo ''
+echo '----sourced bridge workspace----'
+echo ''
+ros2 run ros1_bridge dynamic_bridge
+echo ''
+echo '----Bridge is Alive------'

--- a/create_bridge.sh
+++ b/create_bridge.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source /opt/ros/noetic/setup.bash
+echo '\nSourced ROS1, time to run roscore\n'
+roscore &
+echo '\n roscore is combusting...\n'
+gnome-terminal -- bash -c "bash Bridge.sh; exec bash"


### PR DESCRIPTION
I’ve added custom bridge shell scripts to seamlessly connect our ROS1 and ROS2 environments. In our updated Bridge.sh file, we use absolute paths to source both the ROS1 (Noetic) and ROS2 (Foxy) setup files, as well as the dedicated ros1_bridge workspace’s setup file. This ensures that all necessary environment variables are properly set, allowing the dynamic_bridge executable to locate and run the ros1_bridge package. As a result, our system can now dynamically translate messages between ROS1 and ROS2, bridging the gap between legacy and modern nodes for integrated communication.